### PR TITLE
fix(ConnectSyllables): fix missing syllable options

### DIFF
--- a/packages/entities/exercise-groups/connect-syllables.stories.tsx
+++ b/packages/entities/exercise-groups/connect-syllables.stories.tsx
@@ -1,0 +1,78 @@
+// @ts-ignore TODO: add declaration file
+import { storiesOf } from '@storybook/react-native';
+import * as React from 'react';
+import { View } from 'react-native';
+import { NativeRouter, Redirect, Route } from 'react-router-native';
+
+import { EntityFactory } from '../';
+import { ExerciseComponents } from '../../../src/components/exercises';
+import { LoadSounds } from '../../../src/components/helpers/Audio';
+import { ExerciseGroup } from '../../../src/components/helpers/exercise-group';
+import { play, getSound } from '../../../src/helpers/audio';
+import { PRIMARY } from '../../../src/styles/colors';
+import { AssetResolver } from '../../../src/asset-resolver';
+import { ExerciseGroupTypes } from './index';
+
+const resolver = new AssetResolver();
+const entityFactory = new EntityFactory(resolver);
+
+storiesOf('exercise-groups/ConnectSyllables', module)
+  .add('Diphtongs', () =>
+    createSyllableExercise(
+      ['ausweis', 'hochhaus', 'papier', 'zwiebel'],
+      ['a', 'e', 'i', 'ei']
+    )
+  )
+  .add('Capitalized', () =>
+    createSyllableExercise(
+      ['affe', 'apfel', 'esel', 'oma', 'ausweis'],
+      ['a', 'e', 'i', 'o']
+    )
+  )
+  .add('Umlauts', () =>
+    createSyllableExercise(
+      ['kaefig', 'kaese', 'baecker', 'loeffel', 'muenze'],
+      ['a', 'e', 'i', 'ä', 'ö']
+    )
+  )
+  .add('Qu', () =>
+    createSyllableExercise(['aquarium', 'qualle'], ['a', 'e', 'i', 'u', 'qu'])
+  );
+
+const createSyllableExercise: (
+  newVocabulary: string[],
+  letters: string[]
+) => JSX.Element = (newVocabulary, letters) => {
+  const words = [...newVocabulary];
+  const letter = letters[0];
+  const group = entityFactory.createExerciseGroup(
+    ExerciseGroupTypes.ConnectSyllables,
+    newVocabulary,
+    words,
+    letter,
+    letters,
+    []
+  );
+  return (
+    <LoadSounds
+      sounds={[getSound('correct'), getSound('wrong')]}
+      render={([correctSound, wrongSound]) => (
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: PRIMARY
+          }}
+        >
+          <ExerciseGroup
+            createExerciseComponent={type => ExerciseComponents[type]}
+            group={group}
+            goToNav={() => {}}
+            onCorrect={() => play(correctSound)}
+            onWrong={() => play(wrongSound)}
+            onDone={() => {}}
+          />
+        </View>
+      )}
+    />
+  );
+};

--- a/storybook/stories.js
+++ b/storybook/stories.js
@@ -5,3 +5,4 @@ import '../src/components/common/screens.stories';
 import '../src/components/common/NavigationMenu.stories.js';
 import '../src/components/helpers/difficulty.stories';
 import '../src/components/helpers/PlaySounds.stories';
+import '../packages/entities/exercise-groups/connect-syllables.stories';


### PR DESCRIPTION
handle diphtongs, umlauts, double vowels and capitalized syllables
fix #275, fix #338

@inyono I added a story for some previously failing words. However I couldn't enforce which syllable should be used in the exercise, since I needed to use the `/packages/entities/exercise-groups/connect-syllables.ts` (which chooses the index randomly). So you might have to call the story multiple times for the test case... If you have a better idea for this, please let me know :-)